### PR TITLE
Improve layout for desktop view

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
   <body>
     <p class="title">Conversão KG em SC</p>
 
+    <div class="wrapper">
     <section class="conversion">
       <form id="conversion">
         <div class="inputGroup">
@@ -33,15 +34,6 @@
 
         <button type="submit">CALCULAR</button>
       </form>
-    </section>
-
-    <section id="offering">
-      <div class="offeringContainer">
-        <p>Oferecimento:</p>
-      </div>
-      <div class="offering">
-        <img src="assets/logo.svg" alt="" />
-      </div>
     </section>
 
     <section class="result">
@@ -98,10 +90,18 @@
           </div>
         </div>
 
-        <button type="button" id="back"">VOLTAR</button>
       </div>
     </section>
+    </div>
 
+    <section id="offering">
+      <div class="offeringContainer">
+        <p>Oferecimento:</p>
+      </div>
+      <div class="offering">
+        <img src="assets/logo.svg" alt="" />
+      </div>
+    </section>
     <footer>
       <div class="offeringContainer">
         <p>Todos os direitos reservados ao criador</p>

--- a/scripts.js
+++ b/scripts.js
@@ -2,11 +2,6 @@ function open() {
   document.querySelector('.result').classList.add('active');
 }
 
-function close() {
-  document.querySelector('.result').classList.remove('active');
-  return close;
-}
-
 function calculate(idName, percentage) {
   let oneBag = document.getElementById('oneBag').value;
   let weightBag = document.getElementById('weightBag').value;
@@ -50,4 +45,3 @@ function calcConversion(event) {
 }
 
 document.querySelector('form').addEventListener('submit', calcConversion);
-document.getElementById('back').addEventListener('click', close());

--- a/style.css
+++ b/style.css
@@ -114,29 +114,14 @@ button:hover {
 }
 
 .result {
-  width: 100%;
-  height: 100%;
+  display: none;
   background: var(--brownDark);
-
-  position: fixed;
-  top: 0;
-
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  opacity: 0;
-  visibility: hidden;
-
-  z-index: 999;
-
-  transition: 0.5s;
+  padding: 1rem;
+  border-radius: 1rem;
 }
 
 .result.active {
-  opacity: 1;
-  visibility: visible;
-  transition: 0.5s;
+  display: block;
 }
 
 .result .percentage {
@@ -226,4 +211,19 @@ footer a:hover {
 
 footer .rildo {
   font: 700 1.5rem var(--title-font);
+}
+
+@media (min-width: 1000px) {
+  .wrapper {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    align-items: flex-start;
+  }
+  .conversion {
+    margin: 0;
+  }
+  .result {
+    width: 22rem;
+  }
 }


### PR DESCRIPTION
## Summary
- add a wrapper container so results appear beside the form
- drop back button and overlay behavior
- adapt script to only open result section
- tweak styles for side-by-side layout on large screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840a2cafe888321ba516f2a44018f1c